### PR TITLE
Show all blocks on the map

### DIFF
--- a/Skylight.Incoming/Blocks/BlockChanged.cs
+++ b/Skylight.Incoming/Blocks/BlockChanged.cs
@@ -54,12 +54,11 @@ namespace Skylight
             // Update relevant objects.
             var b = new Block(blockId, x, y, z);
 
-            if (!_specialBlockIds.Contains(blockId))
-            {
-                var subject = Tools.GetPlayerById(playerId, _in.Source);
 
-                b.Placer = subject;
-            }
+            var subject = Tools.GetPlayerById(playerId, _in.Source);
+
+            b.Placer = subject;
+            
 
             _in.Source.Map[x, y, z] = b;
 


### PR DESCRIPTION
Don't exclude blocks that are "special" from being on the map. One
should check the properties of the Block to see if rotation and source
(such as with a portal) are applicable rather than possibly using two
different maps or requiring the user to update their own.

Unfortunately the travis cli build is failing because the system.lazy namespace isn't found (but it's included!) https://travis-ci.org/Decagon/Skylight

However, I shouldn't be getting into the habit of ignoring failing builds.
