### PR TITLE
FIX: CoinGate may be undefinied

### DIFF
--- a/Skylight.Incoming/Blocks/CoinObject.cs
+++ b/Skylight.Incoming/Blocks/CoinObject.cs
@@ -24,12 +24,7 @@ namespace Skylight
                 coinsRequired = m.GetInteger(3);
 
             // Update relevant objects.
-            var b = new CoinBlock(x, y, coinsRequired, false);
-
-            if (id == BlockIds.Action.Gates.Coin)
-            {
-                b.IsGate = true;
-            }
+            var b = new CoinBlock(x, y, coinsRequired, false) {IsGate = (id == BlockIds.Action.Gates.Coin)};
 
             _in.Source.Map[x, y, 0] = b;
 


### PR DESCRIPTION
In addition to simplifying the logic a bit, the b.IsGate may have a null
or empty value if the block is a coin door. This way, the value is
either true or false, nothing in between.
