### PR TITLE
FIX: don't place null blocks on map

### DIFF
--- a/Skylight.Incoming/Blocks/NoteBlock.cs
+++ b/Skylight.Incoming/Blocks/NoteBlock.cs
@@ -1,3 +1,4 @@
+using System;
 using PlayerIOClient;
 using Skylight.Arguments;
 using Skylight.Blocks;
@@ -40,7 +41,14 @@ namespace Skylight
                 b = new PianoBlock(x, y, note);
             }
 
-            _in.Source.Map[x, y, 0] = b;
+            if (b != null)
+            {
+                _in.Source.Map[x, y, 0] = b;
+            }
+            else
+            {
+                throw new Exception("Unknown music block. Not placing on map.");
+            }
 
             // Fire the event.
             var e = new BlockEventArgs(b, _in.Source);


### PR DESCRIPTION
If the noteblock is neither a piano or percussion then make sure that no
null blocks are placed. This helps with future-proofing if a new music
type block is added but if Skylight doesn't implement it then it won't
be a very large issue.
