### PR TITLE
Removed 1s delay

### DIFF
--- a/Skylight.Incoming/In.cs
+++ b/Skylight.Incoming/In.cs
@@ -744,7 +744,7 @@ namespace Skylight
 
             Source.BlocksLoaded = true;
 
-            Thread.Sleep(1000);
+
 
             _playerPhysicsThread = new Thread(UpdatePhysics);
             _playerPhysicsThread.Start();


### PR DESCRIPTION
Removed this thread.sleep delay because it doesn't appear to be doing
anything useful. The player physics are already instantiated in another
thread, so it should be fine. The blocks are forced to load in the
meantime, so it should be good.
