### PR TITLE
Changing to dot net 4

### DIFF
--- a/Skylight.csproj
+++ b/Skylight.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Skylight</RootNamespace>
     <AssemblyName>Skylight</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>


### PR DESCRIPTION
Downgrading because the travis cli build error was introduced when I
upgraded the .net to 4.5.1.

_This finally resolves the Travis CLI System.Lazy namespace not being found_
